### PR TITLE
chore(bump): bump cmomy from 1.1.0 to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 Changelog for `cmomy`
 
+## 1.1.1
+
+Released on 2026-03-20.
+
+### Documentation
+
+- docs: add cmomy.cache to docs ([#58](https://github.com/usnistgov/cmomy/pull/58))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 1.1.0
 
 Released on 2026-03-20.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "cmomy"
-version = "1.1.0"
+version = "1.1.1"
 description = "Central (co)moment calculation/manipulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-03-13T20:52:16.916634895Z"
+exclude-newer = "2026-03-13T21:16:19.520825905Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "cmomy"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-inheritance", marker = "python_full_version < '3.14' or platform_machine != 'x86_64' or sys_platform != 'darwin' or (extra == 'group-5-cmomy-numpy1' and extra == 'group-5-cmomy-numpy2')" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)